### PR TITLE
[PATCH] Added stub to createTask test.

### DIFF
--- a/frontend/cypress/integration/Task_Management/createTask.spec.js
+++ b/frontend/cypress/integration/Task_Management/createTask.spec.js
@@ -7,6 +7,13 @@ it('Should create a new Task', () => {
   cy.intercept(
     {
       method: 'GET',
+      url: '/task',
+    },
+    { fixture: 'taskList.json', statusCode: 200 }
+  );
+  cy.intercept(
+    {
+      method: 'GET',
       url: '/accounts/allEmployees',
     },
     { fixture: 'employeeList.json', statusCode: 200 }


### PR DESCRIPTION
Cypress sometimes visits the Task List after running a create task test. This makes it so it won't fail in those cases.